### PR TITLE
Add version attribute, update source URLs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # passwords
-default['mysql']['server_root_password'] = 'password'
+default['mysql']['server_root_password'] = 'replace_me'
 
 # port
 default['mysql']['port'] = '3306'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,14 +4,16 @@ default['mysql']['server_root_password'] = 'password'
 # port
 default['mysql']['port'] = '3306'
 
+# version
+default['mysql']['version'] = '5.5.43'
 
 # Source URL of Mysql Server
 
 case node['kernel']['machine']
 when 'x86_64'
-	default['mysql']['windows']['url'] = 'http://cdn.mysql.com/Downloads/MySQL-5.5/mysql-5.5.40-winx64.msi'
+	default['mysql']['windows']['url'] = "http://cdn.mysql.com/Downloads/MySQL-5.5/mysql-#{node['mysql']['version']}-winx64.msi"
 when 'i386'
-	default['mysql']['windows']['url'] = 'http://cdn.mysql.com/Downloads/MySQL-5.5/mysql-5.5.40-win32.msi'
+	default['mysql']['windows']['url'] = "http://cdn.mysql.com/Downloads/MySQL-5.5/mysql-#{node['mysql']['version']}-win32.msi"
 end
 
 default['mysql']['windows']['dir'] = "C:\\Mysql"


### PR DESCRIPTION
Version 5.5.40 is no longer available. URL 404s. I updated to latest 5.5 version which is 5.5.43. Version 5.5.42 is still available for download, 5.5.41 is not.
